### PR TITLE
FIX Typo api_pipelines.go

### DIFF
--- a/harness/nextgen/api_pipelines.go
+++ b/harness/nextgen/api_pipelines.go
@@ -156,7 +156,7 @@ func (a *PipelinesApiService) DeletePipeline(ctx context.Context, accountIdentif
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 400 {
-			var v Failure
+			var v ModelError
 			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()


### PR DESCRIPTION
Fix: panic: interface conversion: interface {} is nextgen.ModelError, not nextgen.Failure