### PR TITLE
fixing json tag for AwsCloudProvider type

### DIFF
--- a/harness/cd/graphql/types.go
+++ b/harness/cd/graphql/types.go
@@ -631,7 +631,7 @@ type AwsCloudProvider struct {
 	CloudProvider
 	CEHealthStatus         *CEHealthStatus            `json:"ceHealthStatus,omitempty"`
 	CredentialsType        AwsCredentialsType         `json:"credentialsType,omitempty"`
-	CrossAccountAttributes *AwsCrossAccountAttributes `json:"awsCrossAccountAttributes,omitempty"`
+	CrossAccountAttributes *AwsCrossAccountAttributes `json:"crossAccountAttributes,omitempty"`
 	DefaultRegion          string                     `json:"defaultRegion,omitempty"`
 	Ec2IamCredentials      *Ec2IamCredentials         `json:"ec2IamCredentials,omitempty"`
 	ManualCredentials      *AwsManualCredentials      `json:"manualCredentials,omitempty"`


### PR DESCRIPTION
This is just to fix the json tag for the AwsCloudProvider type in the graphql package.