### PR TITLE
fix: [PL-31762]: additional key 'file' that causes manager to not read file content

### DIFF
--- a/harness/nextgen/api_secrets.go
+++ b/harness/nextgen/api_secrets.go
@@ -831,7 +831,6 @@ func (a *SecretsApiService) PostSecretFileV2(ctx context.Context, accountIdentif
 		return localVarReturnValue, nil, err
 	}
 	if localVarOptionals != nil && localVarOptionals.File.IsSet() {
-		localVarFormParams.Add("file", parameterToString(localVarOptionals.File.Value(), ""))
 		localVarFileName = parameterToString(localVarOptionals.File.Value(), "")
 		localVarFileBytes = file_content
 	}


### PR DESCRIPTION
## Describe your changes
The terraform provider resource secret file doesn't work.
The root cause has been identified here https://harness.atlassian.net/browse/PL-31762 

Due to the duplicate key 'file' put in the multi-part payload, the actual file content stored in harness SM is a string of the path to file instead of the actual file content.

With @rijajoo , we have regenerated the api client code. Using the most recent ng manager api generated client code, the payload looks like below, which still doesn't work. The payload doesn't even contain file data, which is even worse then before.
So instead of re-gen file, we will just do one line fix.

```2023-03-10 18:56:21 [DEBUG] harness-go-sdk harness-go-sdk API Request Details:
---[ REQUEST ]---------------------------------------
POST /gateway/ng/api/v2/secrets/files?accountIdentifier=DNV9I7_YSIS894yYDRn2ng HTTP/1.1
Host: stress.harness.io
User-Agent: terraform-provider-harness-platform-dev
Content-Length: 536
Accept: application/json
Content-Type: multipart/form-data
X-Api-Key: ****_YSIS894yYDRn2ng.6407c5f919446f44c980c76d.qKMMTTYIV2RhFe1v7RAz
Accept-Encoding: gzip

--7befcd9f857cd47dd5a0a63b76de0d57e35da8e0b8fef0f8ddb2612c50ab
Content-Disposition: form-data; name="file"

/Users/xingchi/Downloads/aws-xingchi.pem
--7befcd9f857cd47dd5a0a63b76de0d57e35da8e0b8fef0f8ddb2612c50ab
Content-Disposition: form-data; name="spec"

{
 "secret": {
  "type": "SecretFile",
  "name": "TestAccSecretFile_jFf_x",
  "identifier": "TestAccSecretFile_jFf_x",
  "description": "test",
  "tags": {
   "foo": "bar"
  },
  "spec": {
   "secretManagerIdentifier": "harnessSecretManager"
  }
 }
}
--7befcd9f857cd47dd5a0a63b76de0d57e35da8e0b8fef0f8ddb2612c50ab--

-----------------------------------------------------```

Test:
It has been tested with preQA.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
