### PR TITLE
fix:[PL-39286]: fixed URL Encoding for characters with space

### DIFF
--- a/harness/nextgen/client.go
+++ b/harness/nextgen/client.go
@@ -476,7 +476,7 @@ func (c *APIClient) prepareRequest(
 	}
 
 	// Encode the parameters.
-	url.RawQuery = query.Encode()
+	url.RawQuery = strings.ReplaceAll(query.Encode(), "+", "%20")
 
 	// Generate a new request
 	if body != nil {


### PR DESCRIPTION
## Describe your changes
This is happening because while encoding the spaces it is being sent wrong

Current Behaviour → searchTerm = ABC Project  , Query Goes as → ABC+Project
Expected Behaviour → ABC%20Project

This PR fixes the issues

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
