### PR TITLE
Remove unused field from rancher connector

### DIFF
--- a/harness/nextgen/docs/RancherConnector.md
+++ b/harness/nextgen/docs/RancherConnector.md
@@ -3,7 +3,6 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**ConnectorType** | **string** |  | [default to null]
 **DelegateSelectors** | **[]string** |  | [optional] [default to null]
 **Credential** | [***RancherConnectorConfig**](RancherConnectorConfig.md) |  | [optional] [default to null]
 

--- a/harness/nextgen/model_rancher_connector.go
+++ b/harness/nextgen/model_rancher_connector.go
@@ -11,7 +11,6 @@ package nextgen
 
 // This contains Rancher connector details
 type RancherConnector struct {
-	ConnectorType     string                  `json:"connectorType"`
 	DelegateSelectors []string                `json:"delegateSelectors,omitempty"`
 	Credential        *RancherConnectorConfig `json:"credential,omitempty"`
 }


### PR DESCRIPTION
## Describe your changes
This change removes an unused field from rancher connector, just for cleanup. It isn't causing any failures in TF provider, since we ignore unknown fields while parsing connectors in Harness.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
