### PR TITLE
fix: [CDS-76702]: Remove omitempty

### DIFF
--- a/harness/policymgmt/model_update_request_body2.go
+++ b/harness/policymgmt/model_update_request_body2.go
@@ -14,7 +14,7 @@ type UpdateRequestBody2 struct {
 	// Description of the policy set
 	Description string `json:"description,omitempty"`
 	// Only enabled policy sets are evaluated when evaluating by type/action
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 	// Name of the policy set
 	Name string `json:"name,omitempty"`
 	// Policies linked to this policy set


### PR DESCRIPTION
## Describe your changes
- Due to presence of `omitEmpty` the policymgmt client was was setting the boolean field value to `null` instead of it's actual value to `false. Removing this field let's the marshaller send the field as `false`. 

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
