### PR TITLE
Update enum_ccm_features.go with GOVERNANCE

### DIFF
--- a/harness/nextgen/enum_ccm_features.go
+++ b/harness/nextgen/enum_ccm_features.go
@@ -6,16 +6,19 @@ var CCMFeatures = struct {
 	Billing      CCMFeature
 	Optimization CCMFeature
 	Visibility   CCMFeature
+	Governance   CCMFeature
 }{
 	Billing:      "BILLING",
 	Optimization: "OPTIMIZATION",
 	Visibility:   "VISIBILITY",
+	Governance:   "GOVERNANCE",
 }
 
 var CCMFeaturesSlice = []string{
 	CCMFeatures.Billing.String(),
 	CCMFeatures.Optimization.String(),
 	CCMFeatures.Visibility.String(),
+	CCMFeatures.Governance.String(),
 }
 
 func (e CCMFeature) String() string {


### PR DESCRIPTION
## Describe your changes

GOVERNANCE is now in beta for all cloud providers, we should allow setting this feature on all CCM connectors.

The use of these structs in the terraform provider is hit or miss:

AWS does no real verification, only uses this list for helptext: https://github.com/harness/terraform-provider-harness/blob/main/internal/service/platform/connector/aws_cc.go#L72

Azure and GCP do verification, but the list is hard-coded: 
https://github.com/harness/terraform-provider-harness/blob/main/internal/service/platform/connector/azure_cloud_cost.go#L29
https://github.com/harness/terraform-provider-harness/blob/main/internal/service/platform/connector/gcp_cloud_cost.go#L29

**Currently you cannot enable governance for Azure/GCP connectors in terraform.**

So if we merge this change, I will update the provider for all clouds to use this list for verification.

That would prevent us from allowing some clouds and not others to use future features, so its worth asking if we want to even utilize this struct ongoing or just hard-code the list of features in each connectors reference.

Whatever is decided, I can make the changes in the provider code.

```
╷
│ Error: expected features_enabled.1 to be one of [BILLING OPTIMIZATION VISIBILITY], got GOVERNANCE
│ 
│   with harness_platform_connector_azure_cloud_cost.azure-sales-ccm,
│   on ccm.tf line 73, in resource "harness_platform_connector_azure_cloud_cost" "azure-sales-ccm":
│   73:   features_enabled = ["BILLING", "VISIBILITY", "OPTIMIZATION", "GOVERNANCE"]
│ 
╵
╷
│ Error: expected features_enabled.1 to be one of [BILLING OPTIMIZATION VISIBILITY], got GOVERNANCE
│ 
│   with harness_platform_connector_gcp_cloud_cost.gcpccm,
│   on ccm.tf line 113, in resource "harness_platform_connector_gcp_cloud_cost" "gcpccm":
│  113:   features_enabled      = ["BILLING", "VISIBILITY", "OPTIMIZATION", "GOVERNANCE"]
│ 
╵
```

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
