### PR TITLE
fix: [CDS-92373]: fix gitops cluster linking api's (add agentIdentifier when mapping clusters to envs)

### DIFF
--- a/harness/nextgen/api_clusters.go
+++ b/harness/nextgen/api_clusters.go
@@ -1155,6 +1155,7 @@ ClustersApiService Delete a Cluster by identifier
  * @param optional nil or *ClustersApiDeleteClusterOpts - Optional Parameters:
      * @param "OrgIdentifier" (optional.String) -  Organization Identifier for the Entity.
      * @param "ProjectIdentifier" (optional.String) -  Project Identifier for the Entity.
+     * @param "AgentIdentifier" (optional.String) -  agentIdentifier
      * @param "Scope" (optional.String) -  Scope for the gitops cluster
 @return ResponseDtoBoolean
 */
@@ -1162,6 +1163,7 @@ ClustersApiService Delete a Cluster by identifier
 type ClustersApiDeleteClusterOpts struct {
 	OrgIdentifier     optional.String
 	ProjectIdentifier optional.String
+	AgentIdentifier   optional.String
 	Scope             optional.String
 }
 
@@ -1190,6 +1192,9 @@ func (a *ClustersApiService) DeleteCluster(ctx context.Context, identifier strin
 		localVarQueryParams.Add("projectIdentifier", parameterToString(localVarOptionals.ProjectIdentifier.Value(), ""))
 	}
 	localVarQueryParams.Add("environmentIdentifier", parameterToString(environmentIdentifier, ""))
+	if localVarOptionals != nil && localVarOptionals.AgentIdentifier.IsSet() {
+		localVarQueryParams.Add("agentIdentifier", parameterToString(localVarOptionals.AgentIdentifier.Value(), ""))
+	}
 	if localVarOptionals != nil && localVarOptionals.Scope.IsSet() {
 		localVarQueryParams.Add("scope", parameterToString(localVarOptionals.Scope.Value(), ""))
 	}
@@ -1297,6 +1302,7 @@ ClustersApiService Gets a Cluster by identifier
  * @param optional nil or *ClustersApiGetClusterOpts - Optional Parameters:
      * @param "OrgIdentifier" (optional.String) -  Organization Identifier for the Entity.
      * @param "ProjectIdentifier" (optional.String) -  Project Identifier for the Entity.
+     * @param "AgentIdentifier" (optional.String) -  agentIdentifier
      * @param "Deleted" (optional.Bool) -  Specify whether cluster is deleted or not
 @return ResponseDtoClusterResponse
 */
@@ -1304,6 +1310,7 @@ ClustersApiService Gets a Cluster by identifier
 type ClustersApiGetClusterOpts struct {
 	OrgIdentifier     optional.String
 	ProjectIdentifier optional.String
+	AgentIdentifier   optional.String
 	Deleted           optional.Bool
 }
 
@@ -1332,6 +1339,9 @@ func (a *ClustersApiService) GetCluster(ctx context.Context, identifier string, 
 		localVarQueryParams.Add("projectIdentifier", parameterToString(localVarOptionals.ProjectIdentifier.Value(), ""))
 	}
 	localVarQueryParams.Add("environmentIdentifier", parameterToString(environmentIdentifier, ""))
+	if localVarOptionals != nil && localVarOptionals.AgentIdentifier.IsSet() {
+		localVarQueryParams.Add("agentIdentifier", parameterToString(localVarOptionals.AgentIdentifier.Value(), ""))
+	}
 	if localVarOptionals != nil && localVarOptionals.Deleted.IsSet() {
 		localVarQueryParams.Add("deleted", parameterToString(localVarOptionals.Deleted.Value(), ""))
 	}

--- a/harness/nextgen/docs/ClusterBasicDto.md
+++ b/harness/nextgen/docs/ClusterBasicDto.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Identifier** | **string** | identifier of the cluster | [optional] [default to null]
+**AgentIdentifier** | **string** | agent identifier of the cluster | [optional] [default to null]
 **Name** | **string** | name of the cluster | [optional] [default to null]
 **Scope** | **string** | scope at which the cluster exists in harness gitops, project vs org vs account | [optional] [default to null]
 

--- a/harness/nextgen/docs/ClusterBatchRequest.md
+++ b/harness/nextgen/docs/ClusterBatchRequest.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **ProjectIdentifier** | **string** | project identifier of the cluster | [optional] [default to null]
 **EnvRef** | **string** | environment identifier of the cluster | [default to null]
 **LinkAllClusters** | **bool** | link all clusters | [optional] [default to null]
+**UnlinkAllClusters** | **bool** | unlink all clusters | [optional] [default to null]
 **SearchTerm** | **string** | search term if applicable. only valid if linking all clusters | [optional] [default to null]
 **Clusters** | [**[]ClusterBasicDto**](ClusterBasicDTO.md) | list of cluster identifiers and names | [optional] [default to null]
 

--- a/harness/nextgen/docs/ClusterBatchResponse.md
+++ b/harness/nextgen/docs/ClusterBatchResponse.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Linked** | **int64** | number of clusters linked | [optional] [default to null]
+**Unlinked** | **int64** | number of clusters unlinked | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/nextgen/docs/ClusterRequest.md
+++ b/harness/nextgen/docs/ClusterRequest.md
@@ -5,6 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Identifier** | **string** | identifier of the cluster | [optional] [default to null]
 **OrgIdentifier** | **string** | organization identifier of the cluster | [optional] [default to null]
+**AgentIdentifier** | **string** | agent identifier of the cluster | [optional] [default to null]
 **ProjectIdentifier** | **string** | project identifier of the cluster | [optional] [default to null]
 **EnvRef** | **string** | environment identifier of the cluster | [default to null]
 **Scope** | **string** | scope at which the cluster exists in harness gitops, project vs org vs account | [optional] [default to null]

--- a/harness/nextgen/docs/ClusterResponse.md
+++ b/harness/nextgen/docs/ClusterResponse.md
@@ -6,11 +6,13 @@ Name | Type | Description | Notes
 **ClusterRef** | **string** | identifier of the gitops cluster | [optional] [default to null]
 **OrgIdentifier** | **string** | organization identifier of the cluster | [optional] [default to null]
 **ProjectIdentifier** | **string** | project identifier of the cluster | [optional] [default to null]
+**AgentIdentifier** | **string** | agent identifier of the cluster | [optional] [default to null]
 **AccountIdentifier** | **string** | account identifier of the cluster | [optional] [default to null]
 **EnvRef** | **string** | environment identifier of the cluster | [default to null]
 **LinkedAt** | **int64** | time at which the cluster was linked | [optional] [default to null]
 **Scope** | **string** | scope at which the cluster exists in harness gitops, project vs org vs account | [optional] [default to null]
 **Name** | **string** | name of the gitops cluster | [optional] [default to null]
+**Tags** | **map[string]string** | name of the gitops cluster | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/nextgen/docs/ClustersApi.md
+++ b/harness/nextgen/docs/ClustersApi.md
@@ -368,6 +368,7 @@ Name | Type | Description  | Notes
 
  **orgIdentifier** | **optional.String**| Organization Identifier for the Entity. | 
  **projectIdentifier** | **optional.String**| Project Identifier for the Entity. | 
+ **agentIdentifier** | **optional.String**| agentIdentifier | 
  **scope** | **optional.String**| Scope for the gitops cluster | 
 
 ### Return type
@@ -408,6 +409,7 @@ Name | Type | Description  | Notes
 
  **orgIdentifier** | **optional.String**| Organization Identifier for the Entity. | 
  **projectIdentifier** | **optional.String**| Project Identifier for the Entity. | 
+ **agentIdentifier** | **optional.String**| agentIdentifier | 
  **deleted** | **optional.Bool**| Specify whether cluster is deleted or not | [default to false]
 
 ### Return type

--- a/harness/nextgen/model_cluster_basic_dto.go
+++ b/harness/nextgen/model_cluster_basic_dto.go
@@ -13,6 +13,8 @@ package nextgen
 type ClusterBasicDto struct {
 	// identifier of the cluster
 	Identifier string `json:"identifier,omitempty"`
+	// agent identifier of the cluster
+	AgentIdentifier string `json:"agentIdentifier,omitempty"`
 	// name of the cluster
 	Name string `json:"name,omitempty"`
 	// scope at which the cluster exists in harness gitops, project vs org vs account

--- a/harness/nextgen/model_cluster_batch_request.go
+++ b/harness/nextgen/model_cluster_batch_request.go
@@ -19,6 +19,8 @@ type ClusterBatchRequest struct {
 	EnvRef string `json:"envRef"`
 	// link all clusters
 	LinkAllClusters bool `json:"linkAllClusters,omitempty"`
+	// unlink all clusters
+	UnlinkAllClusters bool `json:"unlinkAllClusters,omitempty"`
 	// search term if applicable. only valid if linking all clusters
 	SearchTerm string `json:"searchTerm,omitempty"`
 	// list of cluster identifiers and names

--- a/harness/nextgen/model_cluster_batch_response.go
+++ b/harness/nextgen/model_cluster_batch_response.go
@@ -13,4 +13,6 @@ package nextgen
 type ClusterBatchResponse struct {
 	// number of clusters linked
 	Linked int64 `json:"linked,omitempty"`
+	// number of clusters unlinked
+	Unlinked int64 `json:"unlinked,omitempty"`
 }

--- a/harness/nextgen/model_cluster_request.go
+++ b/harness/nextgen/model_cluster_request.go
@@ -15,6 +15,8 @@ type ClusterRequest struct {
 	Identifier string `json:"identifier,omitempty"`
 	// organization identifier of the cluster
 	OrgIdentifier string `json:"orgIdentifier,omitempty"`
+	// agent identifier of the cluster
+	AgentIdentifier string `json:"agentIdentifier,omitempty"`
 	// project identifier of the cluster
 	ProjectIdentifier string `json:"projectIdentifier,omitempty"`
 	// environment identifier of the cluster

--- a/harness/nextgen/model_cluster_response.go
+++ b/harness/nextgen/model_cluster_response.go
@@ -17,6 +17,8 @@ type ClusterResponse struct {
 	OrgIdentifier string `json:"orgIdentifier,omitempty"`
 	// project identifier of the cluster
 	ProjectIdentifier string `json:"projectIdentifier,omitempty"`
+	// agent identifier of the cluster
+	AgentIdentifier string `json:"agentIdentifier,omitempty"`
 	// account identifier of the cluster
 	AccountIdentifier string `json:"accountIdentifier,omitempty"`
 	// environment identifier of the cluster
@@ -27,4 +29,6 @@ type ClusterResponse struct {
 	Scope string `json:"scope,omitempty"`
 	// name of the gitops cluster
 	Name string `json:"name,omitempty"`
+	// name of the gitops cluster
+	Tags map[string]string `json:"tags,omitempty"`
 }


### PR DESCRIPTION
## Describe your changes

These models and api's had to be regenerated since agentIdentifier is added to gitops clusters mapped to envs

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
