### PR TITLE
Fix : [CDS-93126]: Remove OmitEmpty

### DIFF
--- a/harness/policymgmt/model_update_request_body2.go
+++ b/harness/policymgmt/model_update_request_body2.go
@@ -14,7 +14,7 @@ type UpdateRequestBody2 struct {
 	// Description of the policy set
 	Description string `json:"description,omitempty"`
 	// Only enabled policy sets are evaluated when evaluating by type/action
-	Enabled bool `json:"enabled,omitempty"`
+	Enabled bool `json:"enabled"`
 	// A string enum value which determines which entities the policy set applies to during evaluation. This feature is not available for all accounts, Contact support if you wish to have it enabled.
 	EntitySelector string `json:"entity_selector,omitempty"`
 	// Name of the policy set


### PR DESCRIPTION
Due to presence of omitEmpty the policymgmt client was was setting the boolean field value to null instead of it's actual value to false. Removing this field let's the marshaller send the field as false

## Describe your changes

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
