### PR TITLE
feat: [PL-48648]: Update TF support for AWS secret manager accesskeyplaintext. 

### DIFF
--- a/harness/nextgen/model_aws_sm_credential_spec_manual_config.go
+++ b/harness/nextgen/model_aws_sm_credential_spec_manual_config.go
@@ -11,6 +11,7 @@ package nextgen
 
 // Returns secret reference access key and secret key of AWS Secret Manager.
 type AwsSmCredentialSpecManualConfig struct {
-	AccessKey string `json:"accessKey"`
-	SecretKey string `json:"secretKey"`
+	AccessKey          string `json:"accessKey,omitempty"`
+	SecretKey          string `json:"secretKey"`
+	AccessKeyPlainText string `json:"accessKeyPlainText,omitempty"`
 }


### PR DESCRIPTION
## Describe your changes
Update TF support for AWS secret manager where now for access key can be added as either secret reference or plain text.

Change required:

Add support for new field accessKeyPlainText introduce in AWS SM.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
