### PR TITLE
fix:[CDS-95932]:Added Support for the reference Token in Tas Connector

### DIFF
--- a/harness/nextgen/model_tas_manual_details.go
+++ b/harness/nextgen/model_tas_manual_details.go
@@ -13,7 +13,8 @@ package nextgen
 type TasManualDetails struct {
 	Username string `json:"username,omitempty"`
 	// Endpoint URL of the TAS Cluster.
-	EndpointUrl string `json:"endpointUrl"`
-	UsernameRef string `json:"usernameRef,omitempty"`
-	PasswordRef string `json:"passwordRef"`
+	EndpointUrl    string `json:"endpointUrl"`
+	UsernameRef    string `json:"usernameRef,omitempty"`
+	PasswordRef    string `json:"passwordRef"`
+	ReferenceToken string `json:"refreshTokenRef"`
 }


### PR DESCRIPTION
## Describe your changes
Update TF support for Tas Connector where now reference Token can also be used.
## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
