### PR TITLE
[feat]: [CDS-98538] Add new get api for overrides v2

### DIFF
--- a/harness/nextgen/api_service_overrides.go
+++ b/harness/nextgen/api_service_overrides.go
@@ -38,29 +38,29 @@ Passed from http.Request or context.Background().
  * @param accountIdentifier
  * @param optional nil or *ServiceOverridesApiCreateServiceOverrideV2Opts - Optional Parameters:
      * @param "Body" (optional.Interface of ServiceOverrideRequestDtov2) -
-     * @param "Branch" (optional.String) - 
-     * @param "FilePath" (optional.String) - 
-     * @param "CommitMsg" (optional.String) - 
-     * @param "IsNewBranch" (optional.Bool) - 
-     * @param "BaseBranch" (optional.String) - 
-     * @param "ConnectorRef" (optional.String) - 
-     * @param "StoreType" (optional.String) - 
-     * @param "RepoName" (optional.String) - 
-     * @param "IsHarnessCodeRepo" (optional.Bool) - 
+     * @param "Branch" (optional.String) -
+     * @param "FilePath" (optional.String) -
+     * @param "CommitMsg" (optional.String) -
+     * @param "IsNewBranch" (optional.Bool) -
+     * @param "BaseBranch" (optional.String) -
+     * @param "ConnectorRef" (optional.String) -
+     * @param "StoreType" (optional.String) -
+     * @param "RepoName" (optional.String) -
+     * @param "IsHarnessCodeRepo" (optional.Bool) -
 @return ResponseServiceOverridesResponseDtov2
 */
 
 type ServiceOverridesApiCreateServiceOverrideV2Opts struct {
-	Body optional.Interface
-	Branch optional.String
-    FilePath optional.String
-    CommitMsg optional.String
-    IsNewBranch optional.Bool
-    BaseBranch optional.String
-    ConnectorRef optional.String
-    StoreType optional.String
-    RepoName optional.String
-    IsHarnessCodeRepo optional.Bool
+	Body              optional.Interface
+	Branch            optional.String
+	FilePath          optional.String
+	CommitMsg         optional.String
+	IsNewBranch       optional.Bool
+	BaseBranch        optional.String
+	ConnectorRef      optional.String
+	StoreType         optional.String
+	RepoName          optional.String
+	IsHarnessCodeRepo optional.Bool
 }
 
 func (a *ServiceOverridesApiService) CreateServiceOverrideV2(ctx context.Context, accountIdentifier string, localVarOptionals *ServiceOverridesApiCreateServiceOverrideV2Opts) (ResponseServiceOverridesResponseDtov2, *http.Response, error) {
@@ -370,22 +370,22 @@ Passed from http.Request or context.Background().
  * @param optional nil or *ServiceOverridesApiGetServiceOverridesV2Opts - Optional Parameters:
      * @param "OrgIdentifier" (optional.String) -
      * @param "ProjectIdentifier" (optional.String) -
-     * @param "Branch" (optional.String) - 
-     * @param "RepoName" (optional.String) - 
-     * @param "LoadFromCache" (optional.String) - 
-     * @param "LoadFromFallbackBranch" (optional.Bool) - 
-     * @param "GetMetadataOnly" (optional.Bool) - 
+     * @param "Branch" (optional.String) -
+     * @param "RepoName" (optional.String) -
+     * @param "LoadFromCache" (optional.String) -
+     * @param "LoadFromFallbackBranch" (optional.Bool) -
+     * @param "GetMetadataOnly" (optional.Bool) -
 @return ResponseServiceOverridesResponseDtov2
 */
 
 type ServiceOverridesApiGetServiceOverridesV2Opts struct {
-	OrgIdentifier     optional.String
-	ProjectIdentifier optional.String
-	Branch optional.String
-    RepoName optional.String
-    LoadFromCache optional.String
-    LoadFromFallbackBranch optional.Bool
-    GetMetadataOnly optional.Bool
+	OrgIdentifier          optional.String
+	ProjectIdentifier      optional.String
+	Branch                 optional.String
+	RepoName               optional.String
+	LoadFromCache          optional.String
+	LoadFromFallbackBranch optional.Bool
+	GetMetadataOnly        optional.Bool
 }
 
 func (a *ServiceOverridesApiService) GetServiceOverridesV2(ctx context.Context, identifier string, accountIdentifier string, localVarOptionals *ServiceOverridesApiGetServiceOverridesV2Opts) (ResponseServiceOverridesResponseDtov2, *http.Response, error) {
@@ -529,40 +529,181 @@ func (a *ServiceOverridesApiService) GetServiceOverridesV2(ctx context.Context, 
 	return localVarReturnValue, localVarHttpResponse, nil
 }
 
+func (a *ServiceOverridesApiService) GetServiceOverrides(ctx context.Context, identifier string, accountIdentifier string, localVarOptionals *ServiceOverridesApiGetServiceOverridesV2Opts) (ResponseServiceOverridesResponseDtov2, *http.Response, error) {
+	var (
+		localVarHttpMethod  = strings.ToUpper("Get")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
+		localVarReturnValue ResponseServiceOverridesResponseDtov2
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/ng/api/serviceOverrides/{identifier}"
+	localVarPath = strings.Replace(localVarPath, "{"+"identifier"+"}", fmt.Sprintf("%v",
+		identifier), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	localVarQueryParams.Add("accountIdentifier", parameterToString(accountIdentifier, ""))
+	if localVarOptionals != nil && localVarOptionals.OrgIdentifier.IsSet() {
+		localVarQueryParams.Add("orgIdentifier",
+			parameterToString(localVarOptionals.OrgIdentifier.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.ProjectIdentifier.IsSet() {
+		localVarQueryParams.Add("projectIdentifier",
+			parameterToString(localVarOptionals.ProjectIdentifier.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.Branch.IsSet() {
+		localVarQueryParams.Add("branch", parameterToString(localVarOptionals.Branch.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.RepoName.IsSet() {
+		localVarQueryParams.Add("repoName", parameterToString(localVarOptionals.RepoName.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.LoadFromFallbackBranch.IsSet() {
+		localVarQueryParams.Add("loadFromFallbackBranch", parameterToString(localVarOptionals.LoadFromFallbackBranch.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.GetMetadataOnly.IsSet() {
+		localVarQueryParams.Add("getMetadataOnly", parameterToString(localVarOptionals.GetMetadataOnly.Value(), ""))
+	}
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{"application/json", "application/yaml"}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+
+	if ctx != nil {
+		// API Key Authentication
+		if auth, ok := ctx.Value(ContextAPIKey).(APIKey); ok {
+			var key string
+			if auth.Prefix != "" {
+				key = auth.Prefix + " " + auth.Key
+			} else {
+				key = auth.Key
+			}
+			localVarHeaderParams["x-api-key"] = key
+
+		}
+	}
+
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody,
+		localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	if localVarHttpResponse.StatusCode < 300 {
+		// If we succeed, return the data, otherwise pass on to decode error.
+		err = a.client.decode(&localVarReturnValue, localVarBody,
+			localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
+			return localVarReturnValue, localVarHttpResponse, err
+		}
+	}
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericSwaggerError{
+			body:  localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		if localVarHttpResponse.StatusCode == 200 {
+			var v ResponseServiceOverridesResponseDtov2
+			err = a.client.decode(&v, localVarBody,
+				localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 400 {
+			var v Failure
+			err = a.client.decode(&v, localVarBody,
+				localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 500 {
+			var v ModelError
+			err = a.client.decode(&v, localVarBody,
+				localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		return localVarReturnValue, localVarHttpResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHttpResponse, nil
+}
+
 /*
 ServiceOverridesApiService Update an ServiceOverride Entity
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param accountIdentifier
  * @param optional nil or *ServiceOverridesApiUpdateServiceOverrideV2Opts - Optional Parameters:
-     * @param "Body" (optional.Interface of ServiceOverrideRequestDtov2) - 
-     * @param "Branch" (optional.String) - 
-     * @param "RepoIdentifier" (optional.String) - 
-     * @param "RootFolder" (optional.String) - 
-     * @param "FilePath" (optional.String) - 
-     * @param "CommitMsg" (optional.String) - 
-     * @param "LastObjectId" (optional.String) - 
-     * @param "ResolvedConflictCommitId" (optional.String) - 
-     * @param "BaseBranch" (optional.String) - 
-     * @param "ConnectorRef" (optional.String) - 
-     * @param "StoreType" (optional.String) - 
-     * @param "LastCommitId" (optional.String) - 
-     * @param "IsNewBranch" (optional.Bool) - 
-     * @param "IsHarnessCodeRepo" (optional.Bool) - 
+     * @param "Body" (optional.Interface of ServiceOverrideRequestDtov2) -
+     * @param "Branch" (optional.String) -
+     * @param "RepoIdentifier" (optional.String) -
+     * @param "RootFolder" (optional.String) -
+     * @param "FilePath" (optional.String) -
+     * @param "CommitMsg" (optional.String) -
+     * @param "LastObjectId" (optional.String) -
+     * @param "ResolvedConflictCommitId" (optional.String) -
+     * @param "BaseBranch" (optional.String) -
+     * @param "ConnectorRef" (optional.String) -
+     * @param "StoreType" (optional.String) -
+     * @param "LastCommitId" (optional.String) -
+     * @param "IsNewBranch" (optional.Bool) -
+     * @param "IsHarnessCodeRepo" (optional.Bool) -
 @return ResponseServiceOverridesResponseDtov2
 */
 
 type ServiceOverridesApiUpdateServiceOverrideV2Opts struct {
-	Body optional.Interface
-	Branch optional.String
-    FilePath optional.String
-    CommitMsg optional.String
-    LastObjectId optional.String
-    BaseBranch optional.String
-    ConnectorRef optional.String
-    StoreType optional.String
-    LastCommitId optional.String
-    IsNewBranch optional.Bool
-    IsHarnessCodeRepo optional.Bool
+	Body              optional.Interface
+	Branch            optional.String
+	FilePath          optional.String
+	CommitMsg         optional.String
+	LastObjectId      optional.String
+	BaseBranch        optional.String
+	ConnectorRef      optional.String
+	StoreType         optional.String
+	LastCommitId      optional.String
+	IsNewBranch       optional.Bool
+	IsHarnessCodeRepo optional.Bool
 }
 
 func (a *ServiceOverridesApiService) UpdateServiceOverrideV2(ctx context.Context, accountIdentifier string, localVarOptionals *ServiceOverridesApiUpdateServiceOverrideV2Opts) (ResponseServiceOverridesResponseDtov2, *http.Response, error) {
@@ -724,34 +865,34 @@ func (a *ServiceOverridesApiService) UpdateServiceOverrideV2(ctx context.Context
 ServiceOverridesApiService import Service Overrides from remote
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param optional nil or *ServiceOverridesApiImportServiceOverridesOpts - Optional Parameters:
-     * @param "Body" (optional.Interface of ServiceOverrideImportRequestDto) - 
-     * @param "AccountIdentifier" (optional.String) - 
-     * @param "ConnectorRef" (optional.String) - 
-     * @param "RepoName" (optional.String) - 
-     * @param "Branch" (optional.String) - 
-     * @param "FilePath" (optional.String) - 
-     * @param "IsForceImport" (optional.Bool) - 
-     * @param "IsHarnessCodeRepo" (optional.Bool) - 
+     * @param "Body" (optional.Interface of ServiceOverrideImportRequestDto) -
+     * @param "AccountIdentifier" (optional.String) -
+     * @param "ConnectorRef" (optional.String) -
+     * @param "RepoName" (optional.String) -
+     * @param "Branch" (optional.String) -
+     * @param "FilePath" (optional.String) -
+     * @param "IsForceImport" (optional.Bool) -
+     * @param "IsHarnessCodeRepo" (optional.Bool) -
 @return ResponseServiceOverrideImportResponseDto
 */
 
 type ServiceOverridesApiImportServiceOverridesOpts struct {
-    Body optional.Interface
-    AccountIdentifier optional.String
-    ConnectorRef optional.String
-    RepoName optional.String
-    Branch optional.String
-    FilePath optional.String
-    IsForceImport optional.Bool
-    IsHarnessCodeRepo optional.Bool
+	Body              optional.Interface
+	AccountIdentifier optional.String
+	ConnectorRef      optional.String
+	RepoName          optional.String
+	Branch            optional.String
+	FilePath          optional.String
+	IsForceImport     optional.Bool
+	IsHarnessCodeRepo optional.Bool
 }
 
 func (a *ServiceOverridesApiService) ImportServiceOverrides(ctx context.Context, accountIdentifier string, localVarOptionals *ServiceOverridesApiImportServiceOverridesOpts) (ResponseServiceOverrideImportResponseDto, *http.Response, error) {
 	var (
-		localVarHttpMethod = strings.ToUpper("Post")
-		localVarPostBody   interface{}
-		localVarFileName   string
-		localVarFileBytes  []byte
+		localVarHttpMethod  = strings.ToUpper("Post")
+		localVarPostBody    interface{}
+		localVarFileName    string
+		localVarFileBytes   []byte
 		localVarReturnValue ResponseServiceOverrideImportResponseDto
 	)
 
@@ -803,8 +944,8 @@ func (a *ServiceOverridesApiService) ImportServiceOverrides(ctx context.Context,
 	}
 	// body params
 	if localVarOptionals != nil && localVarOptionals.Body.IsSet() {
-		
-		localVarOptionalBody:= localVarOptionals.Body.Value()
+
+		localVarOptionalBody := localVarOptionals.Body.Value()
 		localVarPostBody = &localVarOptionalBody
 	}
 
@@ -839,46 +980,46 @@ func (a *ServiceOverridesApiService) ImportServiceOverrides(ctx context.Context,
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-		if err == nil { 
+		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
 
 	if localVarHttpResponse.StatusCode >= 300 {
 		newErr := GenericSwaggerError{
-			body: localVarBody,
+			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v ResponseServiceOverrideImportResponseDto
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 400 {
 			var v Failure
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		if localVarHttpResponse.StatusCode == 500 {
 			var v ModelError
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"));
-				if err != nil {
-					newErr.error = err.Error()
-					return localVarReturnValue, localVarHttpResponse, newErr
-				}
-				newErr.model = v
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
 		}
 		return localVarReturnValue, localVarHttpResponse, newErr
 	}

--- a/harness/nextgen/docs/ServiceOverrideRequestDtov2.md
+++ b/harness/nextgen/docs/ServiceOverrideRequestDtov2.md
@@ -11,6 +11,8 @@ Name | Type | Description | Notes
 **ClusterIdentifier** | **string** |  | [optional] [default to null]
 **Type_** | **string** |  | [default to null]
 **YamlInternal** | **string** |  | [default to null]
+**Yaml** | **string** |  | [default to null]
+**Identifier** | **string** |  | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/nextgen/docs/ServiceOverridesResponseDtov2.md
+++ b/harness/nextgen/docs/ServiceOverridesResponseDtov2.md
@@ -1,8 +1,8 @@
 # ServiceOverridesResponseDtov2
 
 ## Properties
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
+Name | Type       | Description | Notes
+------------ |------------| ------------- | -------------
 **Identifier** | **string** |  | [optional] [default to null]
 **AccountId** | **string** |  | [optional] [default to null]
 **OrgIdentifier** | **string** |  | [optional] [default to null]
@@ -13,7 +13,8 @@ Name | Type | Description | Notes
 **ClusterIdentifier** | **string** |  | [optional] [default to null]
 **Type_** | **string** |  | [optional] [default to null]
 **YamlInternal** | **string** |  | [default to null]
-**NewlyCreated** | **bool** |  | [optional] [default to null]
+**NewlyCreated** | **bool**   |  | [optional] [default to null]
+**Yaml** | **string** |  | [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/nextgen/model_service_override_import_request_dto.go
+++ b/harness/nextgen/model_service_override_import_request_dto.go
@@ -14,10 +14,11 @@ the breaking change with respect to the generated code stub  # Authentication  <
 package nextgen
 
 type ServiceOverrideImportRequestDto struct {
-	OrgIdentifier string `json:"orgIdentifier,omitempty"`
+	OrgIdentifier     string `json:"orgIdentifier,omitempty"`
 	ProjectIdentifier string `json:"projectIdentifier,omitempty"`
-	EnvironmentRef string `json:"environmentRef"`
-	ServiceRef string `json:"serviceRef,omitempty"`
-	InfraIdentifier string `json:"infraIdentifier,omitempty"`
-	Type_ string `json:"type"`
+	EnvironmentRef    string `json:"environmentRef"`
+	ServiceRef        string `json:"serviceRef,omitempty"`
+	InfraIdentifier   string `json:"infraIdentifier,omitempty"`
+	Type_             string `json:"type"`
+	Identifier        string `json:"identifier,omitempty"`
 }

--- a/harness/nextgen/model_service_override_request_dtov2.go
+++ b/harness/nextgen/model_service_override_request_dtov2.go
@@ -22,4 +22,6 @@ type ServiceOverrideRequestDtov2 struct {
 	ClusterIdentifier string `json:"clusterIdentifier,omitempty"`
 	Type_             string `json:"type,omitempty"`
 	YamlInternal      string `json:"yamlInternal,omitempty"`
+	Yaml              string `json:"yaml,omitempty"`
+	Identifier        string `json:"identifier,omitempty"`
 }

--- a/harness/nextgen/model_service_overrides_response_dtov2.go
+++ b/harness/nextgen/model_service_overrides_response_dtov2.go
@@ -25,4 +25,5 @@ type ServiceOverridesResponseDtov2 struct {
 	Type_             string `json:"type,omitempty"`
 	YamlInternal      string `json:"yamlInternal,omitempty"`
 	NewlyCreated      bool   `json:"newlyCreated,omitempty"`
+	Yaml              string `json:"yaml,omitempty"`
 }


### PR DESCRIPTION
## Describe your changes

1. Earlier we were using GET API with path "get-with-yaml" for overrides v2 terraform resource. But with the new resource, we can use the simple GET API. So added that. 

2. Added support for identifier field in overrides v2 request and import request classes. This is to support optional identifier fields in new overrides v2 terraform resource. 
 

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
