### PR TITLE
fix: [CDS-98415] : Change refresh token to omit when empty in json

### DIFF
--- a/harness/nextgen/docs/TasManualDetails.md
+++ b/harness/nextgen/docs/TasManualDetails.md
@@ -1,12 +1,13 @@
 # TasManualDetails
 
 ## Properties
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**Username** | **string** |  | [optional] [default to null]
+Name | Type | Description                      | Notes
+------------ | ------------- |----------------------------------| -------------
+**Username** | **string** |                                  | [optional] [default to null]
 **EndpointUrl** | **string** | Endpoint URL of the TAS Cluster. | [default to null]
-**UsernameRef** | **string** |  | [optional] [default to null]
-**PasswordRef** | **string** |  | [default to null]
+**UsernameRef** | **string** |                                  | [optional] [default to null]
+**PasswordRef** | **string** |                                  | [default to null]
+**ReferenceToken**|**string**|                                  | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/nextgen/model_tas_manual_details.go
+++ b/harness/nextgen/model_tas_manual_details.go
@@ -16,5 +16,5 @@ type TasManualDetails struct {
 	EndpointUrl    string `json:"endpointUrl"`
 	UsernameRef    string `json:"usernameRef,omitempty"`
 	PasswordRef    string `json:"passwordRef"`
-	ReferenceToken string `json:"refreshTokenRef"`
+	ReferenceToken string `json:"refreshTokenRef,omitempty"`
 }


### PR DESCRIPTION
## Describe your changes

Using terraform, when trying to create a tanzu application service (TAS) connector where refresh token is not provided, it was sending "" (empty string) which was causing the check on the backend to fail. Instead, expected to omit that parameter in the json in this case. Added omitempty to omit this parameter when empty. Also added docs for this parameter which was missing.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
