### PR TITLE
fix: [CDS-100484]: Improve error logging, recreate resource if exists in terraform state file.

### DIFF
--- a/harness/nextgen/api_applications.go
+++ b/harness/nextgen/api_applications.go
@@ -634,6 +634,18 @@ func (a *ApplicationsApiService) AgentApplicationServiceGet(ctx context.Context,
 			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
+
+		if localVarHttpResponse.StatusCode >= 400 {
+			var v GatewayruntimeError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v Servicev1Application
 			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/harness/nextgen/api_clusters.go
+++ b/harness/nextgen/api_clusters.go
@@ -473,6 +473,18 @@ func (a *ClustersApiService) AgentClusterServiceGet(ctx context.Context, agentId
 			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
+
+		if localVarHttpResponse.StatusCode >= 400 {
+			var v GatewayruntimeError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v Servicev1Cluster
 			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/harness/nextgen/api_repositories.go
+++ b/harness/nextgen/api_repositories.go
@@ -458,6 +458,18 @@ func (a *RepositoriesApiService) AgentRepositoryServiceGet(ctx context.Context, 
 			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
+
+		if localVarHttpResponse.StatusCode >= 400 {
+			var v GatewayruntimeError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v Servicev1Repository
 			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))


### PR DESCRIPTION
## Describe your changes
When resoruce is deleted outside the terraform flow it should get recreted on terraform apply if resoruce is still in the terraform state file.
Additionally making account, org, project, agent and identifier for repository, cluster and application as immutable fields, as these are not possible to change after creation.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
