### PR TITLE
fix: [CDS-99032]:  Fix error handling for app project mapping

### DIFF
--- a/harness/nextgen/api_applications.go
+++ b/harness/nextgen/api_applications.go
@@ -634,6 +634,18 @@ func (a *ApplicationsApiService) AgentApplicationServiceGet(ctx context.Context,
 			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
+
+		if localVarHttpResponse.StatusCode >= 400 {
+			var v GatewayruntimeError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v Servicev1Application
 			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/harness/nextgen/api_clusters.go
+++ b/harness/nextgen/api_clusters.go
@@ -473,6 +473,18 @@ func (a *ClustersApiService) AgentClusterServiceGet(ctx context.Context, agentId
 			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
+
+		if localVarHttpResponse.StatusCode >= 400 {
+			var v GatewayruntimeError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v Servicev1Cluster
 			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/harness/nextgen/api_project_mappings.go
+++ b/harness/nextgen/api_project_mappings.go
@@ -973,6 +973,18 @@ func (a *ProjectMappingsApiService) AppProjectMappingServiceGetAppProjectMapping
 			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
+
+		if localVarHttpResponse.StatusCode >= 400 {
+			var v GatewayruntimeError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v V1AppProjectMappingV2
 			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/harness/nextgen/api_repositories.go
+++ b/harness/nextgen/api_repositories.go
@@ -458,6 +458,18 @@ func (a *RepositoriesApiService) AgentRepositoryServiceGet(ctx context.Context, 
 			body:  localVarBody,
 			error: localVarHttpResponse.Status,
 		}
+
+		if localVarHttpResponse.StatusCode >= 400 {
+			var v GatewayruntimeError
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+
 		if localVarHttpResponse.StatusCode == 200 {
 			var v Servicev1Repository
 			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))


### PR DESCRIPTION
## Describe your changes 
When resource is not found it should get recreated in terraform, this is fix for app project mapping,
need to cast response to proper error so that it can be handled by harness terraform provider

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
