### PR TITLE
fix: [CDS-98794]: Enable sending array of repo identifiers for multi source apps.

### DIFF
--- a/harness/nextgen/api_applications.go
+++ b/harness/nextgen/api_applications.go
@@ -90,7 +90,11 @@ func (a *ApplicationsApiService) AgentApplicationServiceCreate(ctx context.Conte
 		localVarQueryParams.Add("skipRepoValidation", parameterToString(localVarOptionals.SkipRepoValidation.Value(), ""))
 	}
 	if localVarOptionals != nil && localVarOptionals.RepoIdentifiers.IsSet() {
-		localVarQueryParams.Add("repoIdentifiers", parameterToString(localVarOptionals.RepoIdentifiers.Value(), "multi"))
+		// cast RepoIdentifiers to array of string
+		ids := localVarOptionals.RepoIdentifiers.Value().([]string)
+		for _, id := range ids {
+			localVarQueryParams.Add("repoIdentifiers", parameterToString(id, ""))
+		}
 	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json"}
@@ -3124,7 +3128,11 @@ func (a *ApplicationsApiService) AgentApplicationServiceUpdate(ctx context.Conte
 		localVarQueryParams.Add("skipRepoValidation", parameterToString(localVarOptionals.SkipRepoValidation.Value(), ""))
 	}
 	if localVarOptionals != nil && localVarOptionals.RepoIdentifiers.IsSet() {
-		localVarQueryParams.Add("repoIdentifiers", parameterToString(localVarOptionals.RepoIdentifiers.Value(), "multi"))
+		// cast RepoIdentifiers to array of string
+		ids := localVarOptionals.RepoIdentifiers.Value().([]string)
+		for _, id := range ids {
+			localVarQueryParams.Add("repoIdentifiers", parameterToString(id, ""))
+		}
 	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{"application/json"}


### PR DESCRIPTION
## Describe your changes
When creating gitops app with multi sources we need to provide list of repo identifiers so that repos can be validated. list is sent in as get  query params.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
