### PR TITLE
fix: [CDS-102292]: Added SessionTokenRef to AWS Manual Config

### DIFF
--- a/harness/nextgen/docs/AwsManualConfigSpec.md
+++ b/harness/nextgen/docs/AwsManualConfigSpec.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **AccessKey** | **string** |  | [optional] [default to null]
 **AccessKeyRef** | **string** |  | [optional] [default to null]
 **SecretKeyRef** | **string** |  | [default to null]
+**SessionTokenRef** | **string** |  | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/nextgen/model_aws_manual_config_spec.go
+++ b/harness/nextgen/model_aws_manual_config_spec.go
@@ -14,4 +14,5 @@ type AwsManualConfigSpec struct {
 	AccessKey    string `json:"accessKey,omitempty"`
 	AccessKeyRef string `json:"accessKeyRef,omitempty"`
 	SecretKeyRef string `json:"secretKeyRef"`
+	SessionTokenRef string `json:"sessionTokenRef,omitempty"`
 }


### PR DESCRIPTION
## Describe your changes

Added SessionTokenRef to AWS Manual Config. This parameter is optional, hence added omitempty.

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
