### PR TITLE
feat: [CDS-104611]: Add prefixed agent identifer to delete, update, c…

### DIFF
--- a/harness/nextgen/docs/V1Agent.md
+++ b/harness/nextgen/docs/V1Agent.md
@@ -20,6 +20,7 @@ Name | Type | Description | Notes
 **UpgradeAvailable** | **bool** |  | [optional] [default to null]
 **Scope** | [***V1AgentScope**](v1AgentScope.md) |  | [optional] [default to null]
 **Operator** | [***V1AgentOperator**](v1AgentOperator.md) |  | [optional] [default to null]
+**PrefixedIdentifier** | **string** | The scoped identifier of the agent. This is a combination of the account, org, project, and agent identifiers. | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/nextgen/model_v1_agent.go
+++ b/harness/nextgen/model_v1_agent.go
@@ -30,4 +30,6 @@ type V1Agent struct {
 	UpgradeAvailable bool                `json:"upgradeAvailable,omitempty"`
 	Scope            *V1AgentScope       `json:"scope,omitempty"`
 	Operator         *V1AgentOperator    `json:"operator,omitempty"`
+	// The scoped identifier of the agent. This is a combination of the account, org, project, and agent identifiers.
+	PrefixedIdentifier string `json:"prefixedIdentifier,omitempty"`
 }


### PR DESCRIPTION
## Describe your changes
Response from Get/Create/Update/Delete agent will have additional field `PrefixedIdentifier`, prefixed identifier 
* `account.<agentIdentifier>` - for account level agent
* `org.<agentIdentifier>` - for org level agent
* `<agentIdentifie>` - for project level agent

this is required in terraform resources so that it can be be referenced in resources that depend on agent

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
