### PR TITLE
feat: [PL-58650]: Terraform Changes for Add support for configuring recovery duration in AWS Secrets Manager Connector for secret deletion flow

### DIFF
--- a/harness/cd/unpublished/types.go
+++ b/harness/cd/unpublished/types.go
@@ -60,6 +60,8 @@ type SecretManager struct {
 	KeyName                                       string             `json:"keyName,omitempty"`
 	Credentials                                   string             `json:"credentials,omitempty"`
 	UsePutSecret                                  bool               `json:"usePutSecret,omitempty"`
+	ForceDeleteWithoutRecovery                    bool               `json:"forceDeleteWithoutRecovery,omitempty"`
+	RecoveryWindowInDays                          int64              `json:"recoveryWindowInDays,omitempty"`
 }
 
 type User struct {

--- a/harness/nextgen/docs/AwsSecretManager.md
+++ b/harness/nextgen/docs/AwsSecretManager.md
@@ -1,14 +1,15 @@
 # AwsSecretManager
 
 ## Properties
-Name | Type | Description | Notes
------------- | ------------- | ------------- | -------------
-**Credential** | [***AwsSecretManagerCredential**](AwsSecretManagerCredential.md) |  | [default to null]
-**Region** | **string** |  | [default to null]
-**SecretNamePrefix** | **string** |  | [optional] [default to null]
-**DelegateSelectors** | **[]string** |  | [optional] [default to null]
-**Default_** | **bool** |  | [optional] [default to null]
-**UsePutSecret** | **bool** |  | [optional] [default to null]
-
+Name | Type | Description                   | Notes                         
+------------ | ------------- |-------------------------------|-------------------------------
+**Credential** | [***AwsSecretManagerCredential**](AwsSecretManagerCredential.md) |                               | [default to null]             
+**Region** | **string** |                               | [default to null]             
+**SecretNamePrefix** | **string** |                               | [optional] [default to null]  
+**DelegateSelectors** | **[]string** |                               | [optional] [default to null]  
+**Default_** | **bool** |                               | [optional] [default to null]  
+**UsePutSecret** | **bool** |                               | [optional] [default to null]  
+**ForceDeleteWithoutRecovery** | **bool**  | | [optional] [default to false] |  | [optional] [default to false]
+**RecoveryWindowInDays** | **long**  | |[optional] [default to null]  
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/nextgen/model_aws_secret_manager.go
+++ b/harness/nextgen/model_aws_secret_manager.go
@@ -20,4 +20,6 @@ type AwsSecretManager struct {
 	DelegateSelectors []string `json:"delegateSelectors,omitempty"`
 	Default_          bool     `json:"default,omitempty"`
 	UsePutSecret      bool     `json:"usePutSecret,omitempty"`
+	ForceDeleteWithoutRecovery bool `json:"forceDeleteWithoutRecovery,omitempty"`
+	RecoveryWindowInDays int64 `json:"recoveryWindowInDays,omitempty"`
 }


### PR DESCRIPTION


## Describe your changes
This PR covers changes to give user ability to retrieve a deleted secret in AWS Secret Manager if accidentaly deleted from Harness. When configuring a AWS SM connector in Harness use can now choose between two additional fields:


Tested for:

- Created connector with recovery period of 15 days
- Error is thrown when recovery period is selected as 5 
- Created connector with ForceDeleteWithoutRecovery as true
-
<img width="750" alt="Assume Role using STS on Delegate" src="https://github.com/user-attachments/assets/7bcd814d-b005-4256-b50a-df2b94560110" />
<img width="777" alt="Credertial Type ©" src="https://github.com/user-attachments/assets/c2af5a63-7859-4488-96af-f0cbcd2464a2" />
<img width="1720" alt="Pasted Graphic 31" src="https://github.com/user-attachments/assets/ffad2b7b-93a6-41a9-8154-09abf8ebd65f" />

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
