### PR TITLE
[feat]: [CCM-17096]: Add Dry-run option when creating the auto-stopping rules using terraform

### DIFF
--- a/harness/nextgen/model_opts.go
+++ b/harness/nextgen/model_opts.go
@@ -15,4 +15,5 @@ type Opts struct {
 	AlwaysUsePrivateIp   bool         `json:"always_use_private_ip,omitempty"`
 	AccessDetails        *interface{} `json:"access_details,omitempty"`
 	HideProgressPage     bool         `json:"hide_progress_page,omitempty"`
+	DryRun               bool         `json:"dry_run,omitempty"`
 }

--- a/harness/nextgen/model_service_v2.go
+++ b/harness/nextgen/model_service_v2.go
@@ -28,4 +28,5 @@ type ServiceV2 struct {
 	CreatedAt          string           `json:"created_at,omitempty"`
 	Metadata           *ServiceMetadata `json:"metadata,omitempty"`
 	Status             string           `json:"status,omitempty"`
+	Opts               *Opts            `json:"opts,omitempty"`
 }


### PR DESCRIPTION
## Describe your changes
Add Dry-run optional param to opts in service
API link: https://apidocs.harness.io/tag/Cloud-Cost-AutoStopping-Rules#operation/UpdateAutoStoppingRule

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
