### PR TITLE
[DBOPS-1073]: Update instance for overriding properties in changelogs

### DIFF
--- a/harness/dbops/api/swagger.yaml
+++ b/harness/dbops/api/swagger.yaml
@@ -284,11 +284,11 @@ paths:
         explode: true
         schema:
           type: string
+          default: created
           enum:
           - name
           - updated
           - created
-          default: created
       - name: order
         in: query
         description: Order on the basis of which sorting is done.
@@ -297,10 +297,10 @@ paths:
         explode: true
         schema:
           type: string
+          default: DESC
           enum:
           - ASC
           - DESC
-          default: DESC
       responses:
         "200":
           description: Response body for List Database Schema
@@ -926,11 +926,11 @@ paths:
         explode: true
         schema:
           type: string
+          default: created
           enum:
           - name
           - updated
           - created
-          default: created
       - name: order
         in: query
         description: Order on the basis of which sorting is done.
@@ -939,10 +939,10 @@ paths:
         explode: true
         schema:
           type: string
+          default: DESC
           enum:
           - ASC
           - DESC
-          default: DESC
       requestBody:
         $ref: "#/components/requestBodies/DBInstanceFilterRequest"
       responses:
@@ -1675,7 +1675,7 @@ components:
           location: folder/changelog.yaml
           archivePath: archivePath
         schemaSourceType: Git
-        type: ""
+        type: Repository
         updated: 6
         tags:
           key: tags
@@ -1740,6 +1740,15 @@ components:
         context:
           type: string
           description: Liquibase context
+        liquibaseSubstituteProperties:
+          type: object
+          additionalProperties:
+            type: string
+            x-stoplight:
+              id: lq57gp08jqckf
+          description: properties to substitute in liquibase changelog
+          x-stoplight:
+            id: ylfffbh8lhcwr
       description: Database Instance Request
       x-stoplight:
         id: 1li73zi9bs5oi
@@ -1794,6 +1803,15 @@ components:
           description: Tag on last deployed changeSet
           x-stoplight:
             id: dlbvh5adtk2de
+        liquibaseSubstituteProperties:
+          type: object
+          additionalProperties:
+            type: string
+            x-stoplight:
+              id: szxsmt48sj6o2
+          description: properties to substitute in liquibase changelog
+          x-stoplight:
+            id: zk5v0mxn7p4ns
       description: Database Instance Response
       example:
         identifier: identifier
@@ -2109,10 +2127,10 @@ components:
         filterType:
           type: string
           description: "filter criteria type. Example: Equals, NotEquals"
+          default: Equals
           enum:
           - Equals
           - NotEquals
-          default: Equals
           x-stoplight:
             id: wh3jb1x9a4mvl
         instanceTags:
@@ -2166,22 +2184,22 @@ components:
       title: SortInstance
       type: string
       description: sort for instance entity
+      default: identifier
       enum:
       - name
       - updated
       - created
       - identifier
-      default: identifier
       x-stoplight:
         id: zhl6a0ksg19p2
     OrderInstance:
       title: OrderInstance
       type: string
       description: order of instance entity
+      default: ASC
       enum:
       - DESC
       - ASC
-      default: ASC
       x-stoplight:
         id: l0hdqldkwdms9
     InstanceDetail:
@@ -2642,11 +2660,11 @@ components:
       explode: true
       schema:
         type: string
+        default: created
         enum:
         - name
         - updated
         - created
-        default: created
     Order:
       name: order
       in: query
@@ -2656,10 +2674,10 @@ components:
       explode: true
       schema:
         type: string
+        default: DESC
         enum:
         - ASC
         - DESC
-        default: DESC
     PageIndex:
       name: page
       in: query
@@ -2869,6 +2887,15 @@ components:
               version:
                 type: string
                 description: version of the changelog applied to the database
+              liquibaseSubstituteProperties:
+                type: object
+                additionalProperties:
+                  type: string
+                  x-stoplight:
+                    id: j2at4cjqe9em3
+                description: properties to substitute in liquibase changelog
+                x-stoplight:
+                  id: 411rxl6wqmjnm
           examples:
             example-1:
               value:

--- a/harness/dbops/docs/DbInstanceIn.md
+++ b/harness/dbops/docs/DbInstanceIn.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **Branch** | **string** | branch where the instance is stored  | [optional] [default to null]
 **Connector** | **string** | DB Connector | [default to null]
 **Context** | **string** | Liquibase context | [optional] [default to null]
+**LiquibaseSubstituteProperties** | **map[string]string** | properties to substitute in liquibase changelog | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/dbops/docs/DbInstanceOut.md
+++ b/harness/dbops/docs/DbInstanceOut.md
@@ -14,6 +14,7 @@ Name | Type | Description | Notes
 **LastAppliedTag** | **string** | Most recent tag applied to the database | [optional] [default to null]
 **ToOnboard** | **bool** |  | [optional] [default to null]
 **LastDeployedChangeSetTag** | **string** | Tag on last deployed changeSet | [default to null]
+**LiquibaseSubstituteProperties** | **map[string]string** | properties to substitute in liquibase changelog | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/harness/dbops/model_db_instance_in.go
+++ b/harness/dbops/model_db_instance_in.go
@@ -23,4 +23,6 @@ type DbInstanceIn struct {
 	Connector string `json:"connector"`
 	// Liquibase context
 	Context string `json:"context,omitempty"`
+	// properties to substitute in liquibase changelog
+	LiquibaseSubstituteProperties map[string]string `json:"liquibaseSubstituteProperties,omitempty"`
 }

--- a/harness/dbops/model_db_instance_out.go
+++ b/harness/dbops/model_db_instance_out.go
@@ -32,4 +32,6 @@ type DbInstanceOut struct {
 	ToOnboard      bool   `json:"toOnboard,omitempty"`
 	// Tag on last deployed changeSet
 	LastDeployedChangeSetTag string `json:"lastDeployedChangeSetTag"`
+	// properties to substitute in liquibase changelog
+	LiquibaseSubstituteProperties map[string]string `json:"liquibaseSubstituteProperties,omitempty"`
 }


### PR DESCRIPTION
Terraform: update instance for supporting overriding properties in changelogs

## Describe your changes
1. Can specify 1 or more properties to override
2. Can specify static names and values for those properties in the edit db instance UI
3. These overrides are passed to all liquibase commands.

JIRA -  https://harness.atlassian.net/browse/DBOPS-1073

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
