### PR TITLE
feat: [CCM-24158]: Updating Cluster Orch Config Model and Enhancing Replacement Window Applies to Options

### DIFF
--- a/harness/nextgen/model_cluster_orchestrator.go
+++ b/harness/nextgen/model_cluster_orchestrator.go
@@ -15,6 +15,7 @@ type ClusterOrchDistributionSelector string
 type ClusterOrchNodeDistributionStrategy string
 type ConsolidationPolicy string
 type replacementWindowType string
+type ReplacementWindowType string
 type podEvictor struct {
 	Enabled             bool    `json:"enabled"`
 	EvictSingleReplicas bool    `json:"evict_single_replicas"`
@@ -41,24 +42,25 @@ type ReverseFallback struct {
 	Enabled       bool   `json:"enabled"`
 	RetryInterval string `json:"retry_interval"`
 }
-type commitmentIntegration struct {
+type CommitmentIntegration struct {
 	Enabled        bool   `json:"enabled"`
 	CloudAccountID string `json:"cloud_account_id"`
 }
-type windowAppliesTo struct {
+type WindowAppliesTo struct {
 	HarnessPodEviction bool `json:"harness_pod_eviction"`
 }
-type windowDetails struct {
+
+type WindowDetails struct {
 	Days      []time.Weekday `json:"days"`
 	AllDay    bool           `json:"all_day"`
 	StartTime *TimeInDay     `json:"start_time"`
 	EndTime   *TimeInDay     `json:"end_time"`
 	TimeZone  string         `json:"time_zone"`
 }
-type replacementWindow struct {
-	AppliesTo             *windowAppliesTo      `json:"applies_to"`
-	ReplacementWindowType replacementWindowType `json:"replacement_window_type"`
-	WindowDetails         *windowDetails        `json:"window_details,omitempty"`
+type ReplacementWindow struct {
+	AppliesTo             *WindowAppliesTo      `json:"applies_to"`
+	ReplacementWindowType ReplacementWindowType `json:"replacement_window_type"`
+	WindowDetails         *WindowDetails        `json:"window_details,omitempty"`
 }
 type ClusterOrchConfig struct {
 	SpotDistribution      ClusterOrchDistributionSelector     `json:"spot_distribution"`
@@ -69,8 +71,8 @@ type ClusterOrchConfig struct {
 	OnDemandSplit         int                                 `json:"on_demand_split"`
 	Consolidation         consolidation                       `json:"consolidation"`
 	ReverseFallback       *ReverseFallback                    `json:"reverse_fallback"`
-	CommitmentIntegration *commitmentIntegration              `json:"commitment_integration"`
-	ReplacementWindow     *replacementWindow                  `json:"replacement_window"`
+	CommitmentIntegration *CommitmentIntegration              `json:"commitment_integration"`
+	ReplacementWindow     *ReplacementWindow                  `json:"replacement_window"`
 }
 
 type ClusterOrchestratorUserConfig struct {

--- a/harness/nextgen/model_cluster_orchestrator.go
+++ b/harness/nextgen/model_cluster_orchestrator.go
@@ -14,8 +14,14 @@ import "time"
 type ClusterOrchDistributionSelector string
 type ClusterOrchNodeDistributionStrategy string
 type ConsolidationPolicy string
-type replacementWindowType string
 type ReplacementWindowType string
+
+const (
+	AlwaysReplacementWindow ReplacementWindowType = "Always"
+	NeverReplacementWindow  ReplacementWindowType = "Never"
+	CustomReplacementWindow ReplacementWindowType = "Custom"
+)
+
 type podEvictor struct {
 	Enabled             bool    `json:"enabled"`
 	EvictSingleReplicas bool    `json:"evict_single_replicas"`

--- a/harness/nextgen/model_cluster_orchestrator.go
+++ b/harness/nextgen/model_cluster_orchestrator.go
@@ -54,6 +54,8 @@ type CommitmentIntegration struct {
 }
 type WindowAppliesTo struct {
 	HarnessPodEviction bool `json:"harness_pod_eviction"`
+	Consolidation      bool `json:"consolidation"`
+	ReverseFallback    bool `json:"reverse_fallback"`
 }
 
 type WindowDetails struct {

--- a/harness/nextgen/model_cluster_orchestrator.go
+++ b/harness/nextgen/model_cluster_orchestrator.go
@@ -9,7 +9,9 @@
  */
 package nextgen
 
-import "time"
+import (
+	"time"
+)
 
 type ClusterOrchDistributionSelector string
 type ClusterOrchNodeDistributionStrategy string
@@ -58,18 +60,24 @@ type WindowAppliesTo struct {
 	ReverseFallback    bool `json:"reverse_fallback"`
 }
 
+type TimeInDayForWindow struct {
+	Hour int `json:"hour"`
+	Min  int `json:"minute"`
+}
+
 type WindowDetails struct {
-	Days      []time.Weekday `json:"days"`
-	AllDay    bool           `json:"all_day"`
-	StartTime *TimeInDay     `json:"start_time"`
-	EndTime   *TimeInDay     `json:"end_time"`
-	TimeZone  string         `json:"time_zone"`
+	Days      []time.Weekday      `json:"days"`
+	AllDay    bool                `json:"all_day"`
+	StartTime *TimeInDayForWindow `json:"start_time"`
+	EndTime   *TimeInDayForWindow `json:"end_time"`
+	TimeZone  string              `json:"time_zone"`
 }
 type ReplacementWindow struct {
 	AppliesTo             *WindowAppliesTo      `json:"applies_to"`
 	ReplacementWindowType ReplacementWindowType `json:"replacement_window_type"`
 	WindowDetails         *WindowDetails        `json:"window_details,omitempty"`
 }
+
 type ClusterOrchConfig struct {
 	SpotDistribution      ClusterOrchDistributionSelector     `json:"spot_distribution"`
 	NodeDeletionDelay     int                                 `json:"node_deletion_delay"`


### PR DESCRIPTION
## Describe your changes
This PR aims to update Cluster Orch Config Model in Harness Go SDK, it exports sub-models of configs so that can be initialized and assigned in Terraform Provider Client. Also, it extends Replacement window option for Cluster Orch for Reverse Fallback and Consolidation

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>
  
- Build: `trigger build`
- gitleaks: `trigger gitleaks`
