### PR TITLE
feat: add missing ExecuteOnDelegate option for artifactory connector

### DIFF
--- a/harness/nextgen/model_artifactory_connector.go
+++ b/harness/nextgen/model_artifactory_connector.go
@@ -14,4 +14,5 @@ type ArtifactoryConnector struct {
 	ArtifactoryServerUrl string                     `json:"artifactoryServerUrl"`
 	Auth                 *ArtifactoryAuthentication `json:"auth,omitempty"`
 	DelegateSelectors    []string                   `json:"delegateSelectors,omitempty"`
+	ExecuteOnDelegate    bool                       `json:"executeOnDelegate"`
 }


### PR DESCRIPTION
## Describe your changes

The `ExecuteOnDelegate` option is missing from several types, like `ArtifactoryConnector`. This is to be used later in another PR in https://github.com/harness/terraform-provider-harness 

## Comment Triggers

<details>
  <summary>PR Check triggers</summary>

- Build Test: `trigger build`
- Sub Category Field Check: `trigger subcategoryfieldcheck`
- Git Leaks: `trigger gitleaks`
- Message Check: `trigger messagecheck`
</details>